### PR TITLE
YT-api umbauen v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .cache.shelve*
+__pycache__

--- a/api_helper.py
+++ b/api_helper.py
@@ -78,10 +78,13 @@ class YouTubeApi:
         url_obj = urllib.parse.urlparse(url)
         # we're using parse_qsl instead of parse_qs because nobody cares about list-encoded query parameters
         query = dict(urllib.parse.parse_qsl(url_obj.query))
-        if url_obj.netloc == "www.youtube.com":
+        if url_obj.netloc == "www.youtube.com" or url_obj.netloc == "youtube.com" or url_obj.netloc == "m.youtube.com":
             if url_obj.path == "/playlist":
                 if query.get("list"):
-                    return self._video_ids_from_playlist_id(query.get("list"))
+                     return self._video_ids_from_playlist_id(query.get("list"))
+            if url_obj.path == "/watch":  # TODO parse playlist IDs in watch links?
+                if query.get("v"):
+                    return [query.get("v")]
         raise InvalidLinkFormatException("meh")
 
     @cached

--- a/api_helper.py
+++ b/api_helper.py
@@ -12,6 +12,11 @@ class InvalidLinkFormatException(ValueError):
     pass
 
 
+class VideoNotFoundException(ValueError):
+    def __init__(self, message):
+        super().__init__(f"video not found: {message}")
+
+
 @dataclass
 class YouTubeVideo:
     id: str
@@ -89,7 +94,10 @@ class YouTubeApi:
 
     @cached
     def get_video_data(self, video_id: str) -> YouTubeVideo:
-        video = self.api.get_video_by_id(video_id=video_id).items[0]
+        candidates = self.api.get_video_by_id(video_id=video_id).items
+        if not candidates:
+            raise VideoNotFoundException(video_id)
+        video = candidates[0]
         # get all possible thumbnail variants
         th_v = video.snippet.thumbnails
         # pick highest res thumbnail

--- a/api_helper.py
+++ b/api_helper.py
@@ -73,8 +73,6 @@ class YouTubeApi:
         ]
 
     def get_video_ids_from_link(self, url: str) -> list[str]:
-        # TODO more url matching :)
-        #      evtl. auch einfach machbar für colin/franz?
         url_obj = urllib.parse.urlparse(url)
         # we're using parse_qsl instead of parse_qs because nobody cares about list-encoded query parameters
         query = dict(urllib.parse.parse_qsl(url_obj.query))
@@ -85,6 +83,8 @@ class YouTubeApi:
             if url_obj.path == "/watch":  # TODO parse playlist IDs in watch links?
                 if query.get("v"):
                     return [query.get("v")]
+        elif url_obj.netloc == "youtu.be":
+            return [url_obj.path[1:]]
         raise InvalidLinkFormatException("meh")
 
     @cached

--- a/api_helper.py
+++ b/api_helper.py
@@ -9,7 +9,8 @@ import pyyoutube
 
 
 class InvalidLinkFormatException(ValueError):
-    pass
+    def __init__(self, message):
+        super().__init__(f"invalid link: {message}")
 
 
 class VideoNotFoundException(ValueError):

--- a/api_helper.py
+++ b/api_helper.py
@@ -81,7 +81,7 @@ class YouTubeApi:
         if url_obj.netloc == "www.youtube.com" or url_obj.netloc == "youtube.com" or url_obj.netloc == "m.youtube.com":
             if url_obj.path == "/playlist":
                 if query.get("list"):
-                     return self._video_ids_from_playlist_id(query.get("list"))
+                    return self._video_ids_from_playlist_id(query.get("list"))
             if url_obj.path == "/watch":  # TODO parse playlist IDs in watch links?
                 if query.get("v"):
                     return [query.get("v")]

--- a/app.py
+++ b/app.py
@@ -32,6 +32,9 @@ def get_video_data_multi(url) -> Response:
     # forward the query string from flask to the url parser inside the ytapi
     if request.query_string:
         url += "?" + request.query_string.decode("utf-8")
+    # workaround for werkzeug's wonky double slash handling
+    url = re.sub(r"^https?:\/\/?", "", url)
+    url = f"https://{url}"
     print("fetching video data for", url)
     return jsonify(api.get_video_data_multi(api.get_video_ids_from_link(url)))
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import re
 
 from flask import abort, Flask, jsonify, request, render_template, Response
 
@@ -26,24 +27,13 @@ def home_page() -> str:
     return render_template("home.html")
 
 
-@app.get("/video_ids/<path:url>")
-def get_video_ids(url) -> Response:
+@app.get("/video_data/<path:url>")
+def get_video_data_multi(url) -> Response:
     # forward the query string from flask to the url parser inside the ytapi
     if request.query_string:
         url += "?" + request.query_string.decode("utf-8")
-    print("fetching video ids for", url)
-    return jsonify(api.get_video_ids_from_link(url))
-
-
-@app.get("/video_info/<video_id>")
-def get_video_info(video_id: str) -> Response:
-    return jsonify(api.get_video_data(video_id))
-
-
-@validate_video_list
-@app.post("/video_info")
-def get_multi_video_info() -> Response:
-    return jsonify([api.get_video_data(video_id) for video_id in request.json])
+    print("fetching video data for", url)
+    return jsonify(api.get_video_data_multi(api.get_video_ids_from_link(url)))
 
 
 # POST video_ids als json-array

--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ def get_video_data_multi(url) -> Response:
     if request.query_string:
         url += "?" + request.query_string.decode("utf-8")
     # workaround for werkzeug's wonky double slash handling
-    url = re.sub(r"^https?:\/\/?", "", url)
+    url = re.sub(r"^https?://?", "", url)
     url = f"https://{url}"
     print("fetching video data for", url)
     return jsonify(api.get_video_data_multi(api.get_video_ids_from_link(url)))

--- a/app.py
+++ b/app.py
@@ -4,10 +4,10 @@ import re
 
 from flask import abort, Flask, jsonify, request, render_template, Response
 
-from api_helper import YouTubeApi
+import api_helper
 
 app: Flask = Flask(__name__)
-api = YouTubeApi(os.environ.get("YOUTUBE_API_KEY"))
+api = api_helper.YouTubeApi(os.environ.get("YOUTUBE_API_KEY"))
 
 
 def validate_video_list(func):
@@ -45,6 +45,12 @@ def get_video_data_multi(url) -> Response:
 @app.post("/stats")
 def get_stats_from_video_ids() -> Response:
     return jsonify(api.get_stats(request.json))
+
+
+@app.errorhandler(api_helper.InvalidLinkFormatException)
+@app.errorhandler(api_helper.VideoNotFoundException)
+def handle_api_error(ex):
+    return str(ex), 400
 
 
 if __name__ == "__main__":

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     function get_video_ids() {
-        fetch("/video_ids/" + document.getElementById("url-field").value)
+        fetch("/video_data/" + document.getElementById("url-field").value)
             .then(function (response) {
                 return response.json()
             }).then(function (json) {

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,10 +2,13 @@
     function get_video_ids() {
         fetch("/video_data/" + document.getElementById("url-field").value)
             .then(function (response) {
+                if(!response.ok) throw Error(response.status);
                 return response.json()
             }).then(function (json) {
-            alert(JSON.stringify(json))
-        })
+                alert(JSON.stringify(json))
+            }).catch((err) => {
+                alert("deine mama: " + err)
+            })
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/fetch

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    function get_video_ids() {
+    function get_video_data() {
         fetch("/video_data/" + document.getElementById("url-field").value)
             .then(function (response) {
                 if(!response.ok) throw Error(response.status);
@@ -63,7 +63,7 @@
     </div>
 
     <input type="text" id="url-field"/>
-    <button onclick="get_video_ids();">submit</button>
+    <button onclick="get_video_data();">submit</button>
 </div>
 </body>
 </html>


### PR DESCRIPTION
nachfolge-pr von #6 

jetzt braucht man nur noch einen endpunkt zur abfrage von video-daten, yay.

mehr erklärung aus der commitmsg von 7e7564c9295663ac970284163db5d7b802527e98:
> werkzeug ersetzt in allen eingehenden requests doppelte slashes mit einfachen.
dadurch bekommen wir im parameter nie eine korrekte url.
lösung: kaputtes prefix strippen und manuell https:// prefixen.
das löst teilweise evtl. komisches verhalten aus, ist uns aber egal

> im frontend bei fetch-aufrufen entweder scheme entfernen oder redirects folgen.
note: beim deployment via gunicorn brauchen wir dieses handling eigentlich nicht.
eventuell sollte das in zukunft noch konfigurierbar sein.

<a href="https://gitpod.io/#https://github.com/jemand771/int-youtube-stat/pull/7"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

