### PR TITLE
refactoring + erweiterung API-daten

### DIFF
--- a/api_helper.py
+++ b/api_helper.py
@@ -172,18 +172,20 @@ class YouTubeApi:
 
     def get_stats(self, video_ids: list[str]) -> YouTubeStatistics:
         videos = [self.get_video_data(video_id) for video_id in video_ids]
-        total_duration = sum(video.duration for video in videos)
-        total_views = sum(video.view_count for video in videos)
-        total_likes = sum(video.like_count for video in videos)
-        # TODO I'm going to divide by zero here :^)
-        # TODO refactor assignments? -> **
+        total_avg_data = {
+            f"{'avg' if avg else 'total'}_{prop}":
+            # FIXME this is casting everything to TCount which is *wrong*
+            TCount(the_sum) if not avg else TCount(the_sum // len(videos)) if videos else None
+            for prop, attr in {
+                "duration": "duration",
+                "views": "view_count",
+                "likes": "like_count"
+            }.items()
+            for avg in (False, True)
+            for the_sum in [sum(video.__getattribute__(attr) for video in videos)]
+        }
         # TODO remove need for TCount constructor?
         return YouTubeStatistics(
             total_count=len(videos),
-            total_duration=TDuration(total_duration),
-            avg_duration=TDuration(total_duration // len(videos)),
-            total_likes=TCount(total_likes),
-            avg_likes=TCount(total_likes // len(videos)),
-            total_views=TCount(total_views),
-            avg_views=TCount(total_views // len(videos))
+            **total_avg_data
         )

--- a/api_helper.py
+++ b/api_helper.py
@@ -78,6 +78,11 @@ class YouTubeVideo(YouTubeData):
 class YouTubeStatistics(YouTubeData):
     total_count: int
     total_duration: TDuration
+    avg_duration: TDuration
+    total_likes: TCount
+    avg_likes: TCount
+    total_views: TCount
+    avg_views: TCount
 
 
 def cached(func):
@@ -167,7 +172,18 @@ class YouTubeApi:
 
     def get_stats(self, video_ids: list[str]) -> YouTubeStatistics:
         videos = [self.get_video_data(video_id) for video_id in video_ids]
+        total_duration = sum(video.duration for video in videos)
+        total_views = sum(video.view_count for video in videos)
+        total_likes = sum(video.like_count for video in videos)
+        # TODO I'm going to divide by zero here :^)
+        # TODO refactor assignments? -> **
+        # TODO remove need for TCount constructor?
         return YouTubeStatistics(
             total_count=len(videos),
-            total_duration=TDuration(sum(video.duration for video in videos))
+            total_duration=TDuration(total_duration),
+            avg_duration=TDuration(total_duration // len(videos)),
+            total_likes=TCount(total_likes),
+            avg_likes=TCount(total_likes // len(videos)),
+            total_views=TCount(total_views),
+            avg_views=TCount(total_views // len(videos))
         )

--- a/api_helper.py
+++ b/api_helper.py
@@ -70,6 +70,8 @@ class YouTubeVideo(YouTubeData):
     thumbnail_url: str
     view_count: TCount
     like_count: TCount
+    channel_id: str
+    channel_name: str
 
 
 @dataclass
@@ -155,7 +157,9 @@ class YouTubeApi:
             duration=TDuration(video.contentDetails.get_video_seconds_duration()),
             thumbnail_url=thumbnail.url,
             view_count=TCount(video.statistics.viewCount),
-            like_count=TCount(video.statistics.likeCount)
+            like_count=TCount(video.statistics.likeCount),
+            channel_name=video.snippet.channelTitle,
+            channel_id=video.snippet.channelId
         )
 
     def get_video_data_multi(self, video_ids: list[str]) -> list[YouTubeVideo]:

--- a/api_helper.py
+++ b/api_helper.py
@@ -62,7 +62,6 @@ class TDuration(int):
 @dataclass
 class YouTubeData:
     def __post_init__(self):
-        print("post init")
         for field in dataclasses.fields(self):
             val = getattr(self, field.name)
             if not isinstance(val, field.type):

--- a/api_helper.py
+++ b/api_helper.py
@@ -89,6 +89,7 @@ class YouTubeStatistics(YouTubeData):
     avg_likes: TCount
     total_views: TCount
     avg_views: TCount
+    total_channels: int
 
 
 def cached(func):
@@ -191,5 +192,6 @@ class YouTubeApi:
         }
         return YouTubeStatistics(
             total_count=len(videos),
+            total_channels=len(list(set(video.channel_id for video in videos))),
             **total_avg_data
         )

--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
+import dataclasses
 import functools
 import os
 import re
 
 from flask import abort, Flask, jsonify, request, render_template, Response
+from flask.json import JSONEncoder
 
 import api_helper
 
@@ -20,6 +22,25 @@ def validate_video_list(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+class MyJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        try:
+            if isinstance(obj, api_helper.YouTubeData):
+                return {
+                    key: str(val)
+                    for key, val
+                    in dataclasses.asdict(obj).items()
+                }
+        except TypeError as ex:
+            print(ex)
+            pass
+        return JSONEncoder.default(self, obj)
+
+
+# TODO test? -> <-
+app.json_encoder = MyJSONEncoder
 
 
 @app.get("/")

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from api_helper import YouTubeApi, InvalidLinkFormatException, VideoNotFoundException, YouTubeStatistics
+from api_helper import YouTubeApi, InvalidLinkFormatException, VideoNotFoundException
 import app as main_app
 
 from parameterized import parameterized
@@ -92,8 +92,10 @@ class TestHttpApi(ApiTestBase):
         r = self.app.post("/stats", json=[TestYtApiHelper.TEST_RR_ID] * 3)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
-            YouTubeStatistics(**r.json),
-            self.api.get_stats([TestYtApiHelper.TEST_RR_ID] * 3)
+            r.json,
+            main_app.MyJSONEncoder().default(
+                self.api.get_stats([TestYtApiHelper.TEST_RR_ID] * 3)
+            )
         )
 
     def test_home(self):


### PR DESCRIPTION
* stats: durchschnitt und summe für
  * likes
  * views
  * länge
* stats: anzahl der (einzigartigen) kanäle
* video: kanal-name (und id)
* bisschen formatting-code, um daten-"arten" wie anzahl oder länge einfach im backend formatieren zu können

hintergrund, warum wir das nicht im frontend tun: wir wollen ja keine öffentliche youtube api bereitstellen, deshalb machen wir die daten so "hässlich" wie möglich :b

closes #17
closes #15 
closes #16 

<a href="https://gitpod.io/#https://github.com/jemand771/int-youtube-stat/pull/18"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

